### PR TITLE
Move Clippy arguments into args property

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -15,7 +15,8 @@
 -   id: clippy
     name: clippy
     description: Lint rust sources
-    entry: cargo clippy -- -D warnings
+    entry: cargo clippy
+    args: [--, -D, warnings]
     language: system
     types: [rust]
     pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0]
+
+### Changed
+
+- Allow default arguments for `Clippy` to be overwritten
+
+## [1.0.0]
+
+### Changed
+
+- Replace `rustfmt` with `cargo fmt`
+- Update `pre-commit` to `1.21.0`
+- Update `pre-commit-hooks` to `2.4.0`
+
+[1.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v1.0.0


### PR DESCRIPTION
Moving the default arguments for Clippy into the args property allows
users to overwrite the arguments in their configuration.